### PR TITLE
feat: add `jotdown` for comparison

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,6 +386,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
+name = "jotdown"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5afa77b05ee2811a1c1f4d6b7dce44b65bad966c81072e55ea604d084ad4162b"
+
+[[package]]
+name = "jotdown-app"
+version = "0.0.0"
+dependencies = [
+ "jotdown",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/examples/jotdown-app/Cargo.toml
+++ b/examples/jotdown-app/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "jotdown-app"
+edition.workspace = true
+
+[[bin]]
+name = "jotdown-app"
+path = "app.rs"
+
+[dependencies]
+jotdown = "0.7.0"

--- a/examples/jotdown-app/app.rs
+++ b/examples/jotdown-app/app.rs
@@ -1,0 +1,32 @@
+use std::io::Write;
+
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+    let mut args = std::env::args_os();
+    let _bin = args.next();
+    let path = args.next().expect("no markdown path given");
+    let raw = std::fs::read_to_string(path)?;
+    #[cfg(debug_assertions)]
+    {
+        let stdout = std::io::stdout();
+        let mut stdout = stdout.lock();
+        render(&mut stdout, &raw)?;
+    }
+    #[cfg(not(debug_assertions))]
+    {
+        let mut buffer = Vec::new();
+        render(&mut buffer, &raw)?;
+        std::hint::black_box(buffer);
+    }
+    Ok(())
+}
+
+fn render(
+    writer: &mut dyn Write,
+    raw: &str,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+    let events = jotdown::Parser::new(raw);
+    let html = jotdown::html::render_to_string(events);
+    let _ = writeln!(writer, "{:?}", html);
+
+    Ok(())
+}


### PR DESCRIPTION
Djot is a "kind-of-more-strict-Markdown" which is (supposedly) making it faster and easier to parse. I am curious myself how well it performs. If the premise is true, I would expect smaller binary overhead and faster parsing.